### PR TITLE
feat(ecs): fixed the compilations warnings

### DIFF
--- a/includes/Zipper.hpp
+++ b/includes/Zipper.hpp
@@ -46,8 +46,8 @@ namespace ecs {
                 return std::make_tuple(containers.begin() + _compute_size(containers...) ...);
             }
         private:
+            size_t _size;
             iterator_tuple _begin;
             iterator_tuple _end;
-            size_t _size;
     };
 }

--- a/includes/Zipper_iterator.hpp
+++ b/includes/Zipper_iterator.hpp
@@ -31,7 +31,7 @@ namespace ecs {
          * @param it_tuple tuple of iterators of the containers
          * @param max index of the last element
          */
-        zipper_iterator(iterator_tuple const &it_tuple, size_t max) : _current(it_tuple), _idx(0), _max(max) {
+        zipper_iterator(iterator_tuple const &it_tuple, size_t max) : _current(it_tuple), _max(max), _idx(0) {
             if(_max && !all_set(_seq)) {
                 incr_all(_seq);
             }
@@ -96,6 +96,7 @@ namespace ecs {
     private:
         template<size_t... Is>
         void incr_all(std::index_sequence<Is...> seq) {
+            (void)seq;
             if (_idx >= _max)
                 return;
             _idx++;
@@ -108,10 +109,12 @@ namespace ecs {
         }
         template<size_t... Is>
         bool all_set(std::index_sequence<Is...> seq) {
+            (void)seq;
             return ((std::get<Is>(_current))->has_value() && ...);
         }
         template<size_t... Is>
         value_type to_value(std::index_sequence<Is...> seq) {
+            (void)seq;
             return std::tie(_idx, (std::get<Is>(_current))->value()...);
         };
     private:


### PR DESCRIPTION
- made _size the first variable to be in the same order of the constructor
- swapped _idx and _max so that they are constructed in proper order
- "unsed" the seq variable of incr_all, all_set, and to_value